### PR TITLE
Reduce mobile header footprint

### DIFF
--- a/css/business-casual.css
+++ b/css/business-casual.css
@@ -718,6 +718,25 @@ ol {
   }
 }
 
+@media (max-width: 640px) {
+  :root {
+    --header-height: 60px;
+  }
+
+  .header__inner {
+    padding: 0.5rem 1rem;
+    gap: var(--space-sm);
+  }
+
+  .brand__name {
+    font-size: 1.15rem;
+  }
+
+  .brand__tagline {
+    font-size: 0.85rem;
+  }
+}
+
 @media (max-width: 720px) {
   .hero {
     padding-top: calc(var(--section-spacing) + 2.5rem);


### PR DESCRIPTION
## Summary
- reduce the sticky header height and padding for small screens to free up vertical space
- slightly decrease brand text sizing on mobile for a more compact layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b3e5be270832c949c69e352250bfa)