### PR TITLE
Update portal link and licensure credentials

### DIFF
--- a/about.html
+++ b/about.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -246,7 +246,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/accessibility.html
+++ b/accessibility.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -191,7 +191,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/coaching.html
+++ b/coaching.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -277,7 +277,7 @@
             <p class="footer__disclaimer">Coaching outcomes vary and are not guaranteed. This site does not replace individualized mental health, medical, financial, or legal advice.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/contact.html
+++ b/contact.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}' data-contact-endpoint="mailto:tfosterlcsw@gmail.com">
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}' data-contact-endpoint="mailto:tfosterlcsw@gmail.com">
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -212,7 +212,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/counseling.html
+++ b/counseling.html
@@ -74,7 +74,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -264,7 +264,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/fees-insurance.html
+++ b/fees-insurance.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -262,7 +262,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/gfe-notice.html
+++ b/gfe-notice.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -191,7 +191,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -315,7 +315,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988. Reviews, if referenced, reflect publicly posted feedback; individual experiences vary.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/intake.html
+++ b/intake.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -109,7 +109,7 @@
             <h1>Access the secure portal</h1>
             <p>You will be redirected to the HIPAA-compliant portal to complete paperwork, send secure messages, and manage appointments. If the page does not load automatically, use the button below.</p>
             <div class="hero__actions">
-                <a class="button" id="portal-link" href="https://clientsecure.intakeq.com/portal/teresafoster" rel="noopener" target="_blank" data-track-event="portal_visit">Open client portal</a>
+                <a class="button" id="portal-link" href="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" rel="noopener" target="_blank" data-track-event="portal_visit">Open client portal</a>
                 <a class="button button--outline" href="mailto:tfosterlcsw@gmail.com">Request technical support</a>
             </div>
         </section>
@@ -158,7 +158,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/licensure.html
+++ b/licensure.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -130,7 +130,7 @@
             <ul class="footer__list">
                 <li>Licensed Clinical Social Worker — Indiana Professional Licensing Agency</li>
                 <li>Registered coaching practice serving clients where coaching is permitted</li>
-                <li>National Provider Identifier (NPI): 1518151453</li>
+                <li>National Provider Identifier (NPI): 1477952109</li>
             </ul>
         </section>
 
@@ -139,7 +139,7 @@
             <h2>Academic background</h2>
             <ul class="footer__list">
                 <li>Master of Social Work, University at Buffalo (SUNY)</li>
-                <li>Bachelor of Arts in Psychology, Ohio University</li>
+                <li>Bachelor of Social Work, Ohio University</li>
             </ul>
         </section>
 
@@ -148,17 +148,6 @@
             <h2>Specialized training</h2>
             <ul class="footer__list">
                 <li>EMDRIA Certified EMDR Therapist</li>
-                <li>Certificate in Traumatic Stress Studies, Trauma Research Foundation</li>
-            </ul>
-        </section>
-
-        <section class="section fade-up" data-observe>
-            <span class="section__eyebrow">Ongoing education</span>
-            <h2>Recent continuing education highlights</h2>
-            <ul class="footer__list">
-                <li>2023: Polyvagal Theory in Therapeutic Practice (NICABM)</li>
-                <li>2022: Somatic Experiencing® Introductory Workshop</li>
-                <li>2021: Justice, Equity, Diversity, Inclusion consultation series</li>
             </ul>
         </section>
 
@@ -215,7 +204,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/privacy.html
+++ b/privacy.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -193,7 +193,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/resources.html
+++ b/resources.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -197,7 +197,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/telehealth.html
+++ b/telehealth.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -230,7 +230,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>

--- a/terms.html
+++ b/terms.html
@@ -73,7 +73,7 @@
     <script defer src="js/main.js"></script>
 </head>
 
-<body data-portal-url="https://clientsecure.intakeq.com/portal/teresafoster" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
+<body data-portal-url="https://care.headway.co/providers/teresa-foster?utm_source=pem&utm_medium=direct_link&utm_campaign=101573" data-cta-variants='{"a":"Book a 20-min consultation","b":"Schedule your 20-min consultation"}'>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="header" role="banner">
         <div class="header__inner">
@@ -204,7 +204,7 @@
             <p class="footer__disclaimer">Content is for educational purposes and does not replace individualized mental health or medical care. No outcomes are guaranteed. In an emergency, call 911 or 988.</p>
             <div class="footer__bottom">
                 <span>&copy; <span id="current-year"></span> Teresa R. Foster, L.C.S.W. All rights reserved.</span>
-                <span>NPI 1518151453</span>
+                <span>NPI 1477952109</span>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
- update the client portal URL across the site to the new Headway link
- refresh licensure details with the new NPI and Bachelor of Social Work information
- remove outdated specialized training item and ongoing education section from the credentials page

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b50d49548832cb2d360ac5d66aa95)