### PR TITLE
Remove Twitter card metadata for Open Graph sharing

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="About Teresa Foster, L.C.S.W. | Therapist & Coach in Indiana">
-    <meta name="twitter:description" content="Meet Teresa Foster, L.C.S.W., a trauma-informed therapist and coach in Bloomington, Indiana providing counseling, EMDR, telehealth, and coaching for adults.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/accessibility.html
+++ b/accessibility.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Accessibility Statement | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Accessibility statement for Teresa Foster Therapy outlining efforts to provide inclusive counseling, coaching, and website experiences.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/coaching.html
+++ b/coaching.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Leadership & Life Coaching Nationwide | Teresa Foster L.C.S.W.">
-    <meta name="twitter:description" content="Values-based leadership and life coaching with Teresa Foster, L.C.S.W., offering compassionate accountability and strategy from Bloomington, Indiana to clients nationwide.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/contact.html
+++ b/contact.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Contact Teresa Foster Therapy | Counseling & Coaching Consults">
-    <meta name="twitter:description" content="Contact Teresa Foster, L.C.S.W. to schedule counseling or coaching in Bloomington, Indiana, arrange secure telehealth across the state, or book a consultation online.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/counseling.html
+++ b/counseling.html
@@ -14,10 +14,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Counseling & EMDR in Bloomington, IN | Teresa Foster L.C.S.W.">
-    <meta name="twitter:description" content="Relational, trauma-informed counseling and EMDR for adults with Teresa Foster in Bloomington, Indiana, with secure telehealth sessions for clients across the state.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/fees-insurance.html
+++ b/fees-insurance.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Fees, Insurance & Good Faith Estimates | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Transparent counseling and coaching fees from Teresa Foster, L.C.S.W., plus insurance details and Good Faith Estimate information for Indiana clients.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/gfe-notice.html
+++ b/gfe-notice.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Good Faith Estimate Notice | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Good Faith Estimate notice for counseling and coaching with Teresa Foster, L.C.S.W., supporting price transparency for Indiana clients.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Teresa Foster Therapy | Counseling & Coaching in Bloomington, IN">
-    <meta name="twitter:description" content="Trauma-informed therapy and coaching for adults with Teresa Foster, L.C.S.W. In-person in Bloomington plus secure telehealth across Indiana, with coaching available nationwide.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/intake.html
+++ b/intake.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Client Portal Access | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Secure client portal for scheduling, telehealth links, and forms with Teresa Foster, L.C.S.W. in Bloomington, Indiana.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/licensure.html
+++ b/licensure.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Licensure & Credentials | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Licensure, credentials, and professional memberships for Teresa R. Foster, L.C.S.W., providing counseling in Indiana and coaching online.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/privacy.html
+++ b/privacy.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Privacy Practices | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Privacy practices for Teresa Foster Therapy, explaining how counseling and coaching information is handled online and in session.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/resources.html
+++ b/resources.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Resources & Crisis Support | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Grounding practices, crisis contacts, and supportive resources curated by Teresa Foster, L.C.S.W. for counseling and coaching clients in Indiana.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/telehealth.html
+++ b/telehealth.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Telehealth Counseling Guide for Indiana | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Learn how telehealth sessions with Teresa Foster, L.C.S.W. work, including technology setup, privacy practices, and what to expect for Indiana-based therapy.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",

--- a/terms.html
+++ b/terms.html
@@ -13,10 +13,10 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
     <meta property="og:image:alt" content="Portrait of Teresa R. Foster, L.C.S.W.">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Terms of Use | Teresa Foster Therapy">
-    <meta name="twitter:description" content="Terms of use for the Teresa Foster Therapy website, outlining acceptable use for counseling and coaching visitors.">
-    <meta name="twitter:image" content="https://teresafostertherapy.com/img/IMG_4086.jpeg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="Teresa Foster Therapy">
+    <meta property="og:locale" content="en_US">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- remove Twitter-specific card metadata from each page now that the site is shared mainly via texting
- keep Open Graph tags focused on consistent previews without unused platform-specific entries

## Testing
- Not run (static HTML changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9e12c798832cb3843c18e893e54f)